### PR TITLE
Epic Rating Adjustments

### DIFF
--- a/source/funkin/data/ClientPrefs.hx
+++ b/source/funkin/data/ClientPrefs.hx
@@ -90,6 +90,7 @@ class ClientPrefs {
 	];
 
 	public static var comboOffset:Array<Int> = [0, 0, 0, 0];
+	public static var useEpics:Bool = true;
 	public static var ratingOffset:Int = 0;
 	public static var epicWindow:Int = 22;
 	public static var sickWindow:Int = 45;
@@ -179,6 +180,7 @@ class ClientPrefs {
 		FlxG.save.data.achievementsMap = Achievements.achievementsMap;
 		FlxG.save.data.henchmenDeath = Achievements.henchmenDeath;
 
+		FlxG.save.data.useEpics = useEpics;
 		FlxG.save.data.ratingOffset = ratingOffset;
 		FlxG.save.data.epicWindow = epicWindow;
 		FlxG.save.data.sickWindow = sickWindow;
@@ -314,6 +316,9 @@ class ClientPrefs {
 			comboOffset = FlxG.save.data.comboOffset;
 		}
 
+		if(FlxG.save.data.useEpics != null) {
+			useEpics = FlxG.save.data.useEpics;
+		}
 		if(FlxG.save.data.ratingOffset != null) {
 			ratingOffset = FlxG.save.data.ratingOffset;
 		}

--- a/source/funkin/data/options/GameplaySettingsSubState.hx
+++ b/source/funkin/data/options/GameplaySettingsSubState.hx
@@ -89,6 +89,13 @@ class GameplaySettingsSubState extends BaseOptionsMenu
 		option.decimals = 1;
 		option.onChange = onChangeHitsoundVolume;
 
+		var option:Option = new Option('Use Epic Ratings', //Name
+			'If checked, adds Epic Ratings as a bonus judgement above sick (does not affect accuracy, only your score).', //Description
+			'useEpics', //Save data variable name
+			'bool', //Variable type
+			true); //Default value
+		addOption(option);
+
 		var option:Option = new Option('Rating Offset',
 			'Changes how late/early you have to hit for a "Sick!"\nHigher values mean you have to hit later.',
 			'ratingOffset',

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -416,14 +416,16 @@ class PlayState extends MusicBeatState
 		NoteAnimations.resetToDefault();
 
 		// Ratings
-		var rating:Rating = new Rating('epic');
-		rating.ratingMod = 1;
-		rating.score = 500;
-		rating.noteSplash = true;
-		ratingsData.push(rating);
+		if(ClientPrefs.useEpics) {
+			var rating:Rating = new Rating('epic');
+			rating.ratingMod = 1;
+			rating.score = 500;
+			rating.noteSplash = true;
+			ratingsData.push(rating);
+		}
 
 		var rating:Rating = new Rating('sick');
-		rating.ratingMod = 0.9825;
+		rating.ratingMod = 1;
 		rating.score = 350;
 		rating.noteSplash = true;
 		ratingsData.push(rating);


### PR DESCRIPTION
I've added a toggle in the Gameplay Settings for the Epic Rating. Additionally, the Epic Rating and Sick Rating have the same accuracyMod value (or whatever it was called idr), making Epic Ratings no longer required for 100% accuracy and more of an extra bonus rank.