### PR TITLE
Fix a small mistype in the getEaseFromString function.

### DIFF
--- a/source/funkin/utils/CoolUtil.hx
+++ b/source/funkin/utils/CoolUtil.hx
@@ -196,7 +196,7 @@ class CoolUtil
 			case 'sineout': FlxEase.sineOut;
 			case 'smoothstepin': FlxEase.smoothStepIn;
 			case 'smoothstepinout': FlxEase.smoothStepInOut;
-			case 'smoothstepout': FlxEase.smoothStepInOut;
+			case 'smoothstepout': FlxEase.smoothStepOut;
 			case 'smootherstepin': FlxEase.smootherStepIn;
 			case 'smootherstepinout': FlxEase.smootherStepInOut;
 			case 'smootherstepout': FlxEase.smootherStepOut;


### PR DESCRIPTION
Fixes an old issue from Psych Engine, where `'smoothstepout'` would return `FlxEase.smoothStepInOut` rather than `FlxEase.smoothStepOut` in the `CoolUtil` Class.