### PR TITLE
Small fix for Thorns cutscene being blurry

### DIFF
--- a/content/base-game/stages/schoolEvil.hx
+++ b/content/base-game/stages/schoolEvil.hx
@@ -92,6 +92,7 @@ function schoolIntro(dialogueBox)
 	senpaiEvil.updateHitbox();
 	senpaiEvil.screenCenter();
 	senpaiEvil.cameras = [camOther];
+	senpaiEvil.antialiasing = false;
 	senpaiEvil.x += 300;
 	
 	var songName:String = Paths.formatToSongPath(PlayState.SONG.song);


### PR DESCRIPTION
Fixes Senpai in Thorns being blurry because of the recent global anti-aliasing change.

before:
<img width="448" height="576" alt="image" src="https://github.com/user-attachments/assets/857ae698-92f3-4780-a4ec-9284ae5a74f5" />

after:
<img width="449" height="590" alt="image" src="https://github.com/user-attachments/assets/9664943b-0d64-4d00-9fda-ad279dcf8acd" />
