### PR TITLE
Small fix to the .hxpkg file.

### DIFF
--- a/.hxpkg
+++ b/.hxpkg
@@ -50,7 +50,7 @@
                 "version": "9.4.1"
             },
             {
-                "name": "discord_rpc",
+                "name": "hxdiscord_rpc",
                 "version": "1.2.4"
             },
             {


### PR DESCRIPTION
Fixes the .hxpkg file using `discord_rpc` and not `hxdiscord_rpc`.