### PR TITLE
Small layering tweak to little buddies in chart editor.

### DIFF
--- a/source/funkin/states/editors/ChartEditorState.hx
+++ b/source/funkin/states/editors/ChartEditorState.hx
@@ -389,6 +389,8 @@ class ChartEditorState extends MusicBeatState
 		// gradient.alpha = 1;
 		add(gradient);
 		
+		createFriends();
+		
 		shit = new FlxSprite();
 		shit.visible = false;
 		add(shit);
@@ -575,8 +577,6 @@ class ChartEditorState extends MusicBeatState
 		lastSong = currentSongName;
 		
 		updateGrid();
-		
-		createFriends();
 		
 		super.create();
 	}


### PR DESCRIPTION
Small tweak to the chart editor, so that the actual info and stuff is layered above the buddies.

PR'd this because i thought it looked weird with how the characters drop down would be hidden by the buddies sometimes.

how it looks now:
<img width="459" height="517" alt="image" src="https://github.com/user-attachments/assets/96369f2b-70bb-4362-bac5-e0e00ec31c87" />
