### PR TITLE
Fix ChartEditorState looking for charts in an old file path

### DIFF
--- a/source/funkin/states/editors/ChartEditorState.hx
+++ b/source/funkin/states/editors/ChartEditorState.hx
@@ -3874,7 +3874,7 @@ class ChartEditorState extends MusicBeatState
 		try
 		{
 			final songName = Paths.sanitize(song);
-			PlayState.SONG = Chart.fromPath(Paths.json('$songName/${Difficulty.getDifficultyFilePath()}'));
+			PlayState.SONG = Chart.fromPath(Paths.json('$songName/data/${Difficulty.getDifficultyFilePath()}'));
 		}
 		catch (e)
 		{


### PR DESCRIPTION
ChartEditorState was never updated to reflect charts being moved to `songname/data`, so this pull request fixes that. 