### PR TITLE
BlendMode support for Atlases via Bopper's

### DIFF
--- a/source/funkin/objects/Bopper.hx
+++ b/source/funkin/objects/Bopper.hx
@@ -1,5 +1,7 @@
 package funkin.objects;
 
+import flash.display.BlendMode;
+
 import openfl.display.Graphics;
 
 import flixel.math.FlxRect;
@@ -277,6 +279,7 @@ class Bopper extends FlxSprite
 		animateAtlas.alpha = alpha;
 		animateAtlas.visible = visible;
 		animateAtlas.angle = angle;
+		animateAtlas.blend = blend ?? BlendMode.NORMAL; // oh my fucking god duskie bro.
 		animateAtlas.antialiasing = antialiasing;
 		animateAtlas.colorTransform = colorTransform;
 		animateAtlas.color = color;


### PR DESCRIPTION
It is as simple as it gets. A single line difference that just allows for atlases to use blendmodes!

(Please note this is my first ever P.R. If this is messy, that should explain why)