### PR TITLE
Fix Pixel Splashes

### DIFF
--- a/assets/game/data/noteskins/pixel.json
+++ b/assets/game/data/noteskins/pixel.json
@@ -132,7 +132,7 @@
 				-2
 			],
 			"xmlName": "splash1",
-			"anim": "splash1"
+			"anim": "note0"
 		},		
         {
 			"offsets": [
@@ -140,15 +140,23 @@
 				-2
 			],
 			"xmlName": "splash2",
-			"anim": "splash2"
+			"anim": "note1"
 		},
         {
 			"offsets": [
 				-2,
 				-2
 			],
+			"xmlName": "splash1",
+			"anim": "note2"
+		},
+		{
+			"offsets": [
+				-2,
+				-2
+			],
 			"xmlName": "splash2",
-			"anim": "splash3"
+			"anim": "note3"
 		}
 	],
 	"noteAnimations": [


### PR DESCRIPTION
title is self-explanatory

the pixel splash anim data was changed in the commit that added the pixel splashes and it caused the splashes to not animate when hitting a note

i made the left and up notes use the first animation and the down and right notes use the second animation
i hope thats okay???

if you want to change that its fine i just wanted to fix the splashes from not animating