### PR TITLE
Fix Story Mode crash caused by there being no weeks

### DIFF
--- a/source/funkin/states/StoryMenuState.hx
+++ b/source/funkin/states/StoryMenuState.hx
@@ -16,6 +16,7 @@ import funkin.states.*;
 import funkin.states.substates.*;
 import funkin.objects.*;
 import funkin.backend.Difficulty;
+import funkin.backend.FallbackState;
 
 class StoryMenuState extends MusicBeatState
 {
@@ -55,6 +56,15 @@ class StoryMenuState extends MusicBeatState
 		
 		PlayState.isStoryMode = true;
 		WeekData.reloadWeekFiles(true);
+		
+		if (WeekData.weeksList.length == 0)
+		{
+			CoolUtil.setTransSkip(true, false);
+			persistentUpdate = false;
+			FlxG.switchState(() -> new FallbackState('Cannot load Story Mode as there are no weeks loaded.', () -> FlxG.switchState(MainMenuState.new)));
+			return;
+		}
+		
 		if (curWeek >= WeekData.weeksList.length) curWeek = 0;
 		persistentUpdate = persistentDraw = true;
 		
@@ -190,6 +200,8 @@ class StoryMenuState extends MusicBeatState
 	
 	override function update(elapsed:Float)
 	{
+		if (WeekData.weeksList.length == 0) return;
+		
 		scriptGroup.call('onUpdate', [elapsed]);
 		
 		// scoreText.setFormat('VCR OSD Mono', 32);


### PR DESCRIPTION
unlike freeplay story mode had no checks in case there are 0 weeks loaded, which resulted in a null object reference

now it refuses to load just like freeplay
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/a697b958-b090-4cb5-bd3c-c0ff01249747" />
