### PR TITLE
Remove `haxelib run hxpkg setup` from compile instructions as the command alias for hxpkg is never used

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ In a cmd within the project directory, in order run...
 
 ```sh
 haxelib git hxpkg https://github.com/ADA-Funni/hxpkg add-hmm-compatibility
-haxelib run hxpkg setup
 haxelib run hxpkg install
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ In a cmd within the project directory, in order run...
 
 ```sh
 haxelib git hxpkg https://github.com/ADA-Funni/hxpkg add-hmm-compatibility
-haxelib run hxpkg setup
 haxelib run hxpkg to-hmm
 
 cargo install --git https://github.com/ninjamuffin99/hmm-rs hmm-rs


### PR DESCRIPTION
The command alias for hxpkg is never used, so it is pointless to tell the user to run `haxelib run hxpkg setup`.