### PR TITLE
new song start stutter fix

### DIFF
--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -1311,6 +1311,9 @@ class PlayState extends MusicBeatState
 		
 		audio.volume = 0;
 		
+		audio.play();
+		audio.pause();
+		
 		scripts.set('vocals', audio);
 		scripts.set('inst', audio.inst);
 		


### PR DESCRIPTION
play() was causing a lag spike in startSong so moved it to also run in generateSong

before

https://github.com/user-attachments/assets/f806e0db-f603-4106-9997-c7f46e94f739


after

https://github.com/user-attachments/assets/6ad48015-6bbb-4919-94fb-7257283f2da9

