### PR TITLE
coyote timer for hold notes

### DIFF
--- a/source/funkin/data/ClientPrefs.hx
+++ b/source/funkin/data/ClientPrefs.hx
@@ -66,8 +66,6 @@ class ClientPrefs
 	@saveVar public static var camFollowsCharacters:Bool = true;
 	
 	// gameplay ------------------------------------------------------------------------//
-	@saveVar public static var guitarHeroSustains:Bool = true;
-	
 	@saveVar public static var mechanics:Bool = true;
 	
 	@saveVar public static var modcharts:Bool = true;

--- a/source/funkin/objects/note/Note.hx
+++ b/source/funkin/objects/note/Note.hx
@@ -67,6 +67,9 @@ class Note extends FunkinSprite implements funkin.game.modchart.IModNote
 	public var tail:Array<Note> = []; // for sustains
 	public var parent:Note;
 	
+	// 0 to 1, 1 = missed
+	public var coyoteProgress:Float = 0;
+	
 	/**
 	 * if true, the note cannot be hit.
 	 * 
@@ -268,7 +271,7 @@ class Note extends FunkinSprite implements funkin.game.modchart.IModNote
 			
 			animSuffix = prevNote.animSuffix;
 			
-			missHealth = ClientPrefs.guitarHeroSustains ? 0 : 0.0475;
+			missHealth = 0.0475;
 			
 			if (prevNote.isSustainNote)
 			{
@@ -455,8 +458,10 @@ class Note extends FunkinSprite implements funkin.game.modchart.IModNote
 		var absDiff = Math.abs(diff);
 		canBeHit = absDiff <= actualHitbox;
 		
-		if (strumTime < Conductor.songPosition - Conductor.safeZoneOffset && !wasGoodHit) tooLate = true;
-		
+		if (!isSustainNote) if (strumTime < Conductor.songPosition - Conductor.safeZoneOffset && !wasGoodHit) tooLate = true;
+		else if (parent != null) // coyote timer
+			if (parent.coyoteProgress >= 1 && !wasGoodHit) tooLate = true;
+			
 		if (tooLate && !inEditor)
 		{
 			if (alpha > 0.3) alpha = 0.3;

--- a/source/funkin/objects/note/PlayField.hx
+++ b/source/funkin/objects/note/PlayField.hx
@@ -297,7 +297,7 @@ class PlayField extends FlxTypedContainer<StrumNote>
 			}
 		}
 		
-		if (ClientPrefs.guitarHeroSustains && !note.isSustainNote)
+		if (!note.isSustainNote)
 		{
 			for (sustain in note.tail)
 				sustain.blockHit = false; // makes the hold note active when you press the base note
@@ -438,7 +438,7 @@ class PlayField extends FlxTypedContainer<StrumNote>
 		if (noteScriptRet != ScriptConstants.STOP_FUNC) PlayState.instance.scripts.call('noteMiss', scriptArgs, false, [note.noteType]);
 		
 		// hold note missing stuff, makes the hold unhittable (and kills it, might make it just transparent if i can fix some stuff)
-		if (ClientPrefs.guitarHeroSustains && !note.hitCausesMiss && !note.canMiss)
+		if (!note.hitCausesMiss && !note.canMiss)
 		{
 			final tail = (note.isSustainNote ? note.parent.tail : note.tail);
 			for (sustain in tail)

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -1430,7 +1430,7 @@ class PlayState extends MusicBeatState
 					sustainNote.gfNote = swagNote.gfNote;
 					sustainNote.noteType = swagNote.noteType;
 					
-					if (ClientPrefs.guitarHeroSustains && !swagNote.hitCausesMiss && !swagNote.canMiss) sustainNote.blockHit = true; // stops you from holding a note without key pressing first
+					if (!swagNote.hitCausesMiss && !swagNote.canMiss) sustainNote.blockHit = true; // stops you from holding a note without key pressing first
 					if (!sustainNote.alive) break;
 					
 					sustainNote.ID = unspawnNotes.length;
@@ -2790,27 +2790,42 @@ class PlayState extends MusicBeatState
 				{
 					if (daNote.isSustainNote
 						&& !daNote.blockHit
-						&& input.inputPressed(daNote.noteData)
+						&& (input.inputPressed(daNote.noteData) || (daNote.wasGoodHit && daNote.parent.coyoteProgress < 1))
 						&& Conductor.songPosition >= daNote.strumTime
 						&& !daNote.tooLate
-						&& !daNote.wasGoodHit) daNote.playField.onNoteHit.dispatch(daNote, daNote.playField);
+						&& !daNote.wasGoodHit)
+					{
+						daNote.parent.coyoteProgress = 0;
+						daNote.playField.onNoteHit.dispatch(daNote, daNote.playField);
+					}
 				}
 				
-				if (ClientPrefs.guitarHeroSustains)
+				// hold note drop
+				if (!daNote.playField.autoPlayed && daNote.playField.inControl && daNote.playField.playerControls)
 				{
-					// hold note drop
-					
-					if (!daNote.playField.autoPlayed && daNote.playField.inControl && daNote.playField.playerControls)
+					if (daNote.isSustainNote
+						&& !daNote.blockHit
+						&& !daNote.ignoreNote
+						&& !input.inputPressed(daNote.noteData)
+						&& !endingSong
+						&& !daNote.wasGoodHit)
 					{
-						if (daNote.isSustainNote
-							&& !daNote.blockHit
-							&& !daNote.ignoreNote
-							&& !input.inputPressed(daNote.noteData)
-							&& !endingSong
-							&& (daNote.tooLate || !daNote.wasGoodHit))
+						if (daNote.tooLate)
 						{
 							daNote.playField.onNoteMiss.dispatch(daNote, daNote.playField);
-						}
+							
+							combo = 0; // Repeat the miss code unconditionally because the actualMiss signal callback comes after the function that makes notes unable to miss
+							audio.miss();
+							
+							if (instakillOnMiss) doDeathCheck(true);
+							
+							songMisses++;
+							if (!practiceMode) songScore -= 10;
+							
+							totalPlayed++;
+							RecalculateRating(true);
+						};
+						else daNote.parent.coyoteProgress += FlxG.elapsed / 0.45;
 					}
 				}
 			});

--- a/source/funkin/states/options/GameplaySettingsSubState.hx
+++ b/source/funkin/states/options/GameplaySettingsSubState.hx
@@ -29,10 +29,6 @@ class GameplaySettingsSubState extends BaseOptionsMenu
 		var option:Option = new Option('Ghost Tapping', "If checked, you won't get misses from pressing keys\nwhile there are no notes able to be hit.", 'ghostTapping', BOOL, true);
 		addOption(option);
 		
-		var option:Option = new Option('Sustains as One Note', "If checked, hold notes will be dropped if let go too early and only count as one miss.\nDisable for the old input.",
-			'guitarHeroSustains', 'bool', true);
-		addOption(option);
-		
 		var option:Option = new Option('Disable Reset Button', "If checked, pressing Reset won't do anything.", 'noReset', BOOL, false);
 		addOption(option);
 		


### PR DESCRIPTION
Changes:

* Removes guitarHeroSustains option and merges it into the default behaviour.
* Adds a coyote timer that triggers on release that gives a 0.45 second grace period before you actually miss a note similarly to games based on Stepmania.

This should make the sustain inputs much more forgiving which is good for charts with a lot of hold notes. More useful especially here considering the subdivisions ending up making it harder to repress a released hold