### PR TITLE
[CHORE] remove linc_luajit define as useless and disable `DISCORD_ALLOWED` for non-desktop targets, and set `VIDEOS_ALLOWED` to the current target hxvlc uses

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -7,10 +7,6 @@
     <!--Switch Export with Unique ApplicationID and Icon-->
     <set name="APP_ID" value="0x0100f6c013bbc000" />
 
-    <!-- NOTE TO SELF: DISABLE THIS IF ISSUES ARE FOUND -->
-    <haxedef name="LINC_LUA_RELATIVE_DYNAMIC_LIB"/>
-    <!-- stable luas PUT AFTER FIRST LINE WITH APP NAME AND ETC -->
-
     <!--The flixel preloader is not accurate in Chrome. You can use it regularly if you embed the swf into a html file
 		or you can set the actual size of your file manually at "FlxPreloaderBase-onUpdate-bytesTotal"-->
     <!-- <app preloader="Preloader" resizable="true" /> -->
@@ -39,7 +35,7 @@
     <!--ENGINE CUSTOMIZATION-->
     <define name="MODS_ALLOWED" if="desktop" />
     <define name="VIDEOS_ALLOWED" if="cpp" />
-    <define name="DISCORD_ALLOWED" if="cpp"/>
+    <define name="DISCORD_ALLOWED" if="desktop"/>
 
     <!-- _____________________________ Path Settings ____________________________ -->
 

--- a/Project.xml
+++ b/Project.xml
@@ -34,7 +34,7 @@
 
     <!--ENGINE CUSTOMIZATION-->
     <define name="MODS_ALLOWED" if="desktop" />
-    <define name="VIDEOS_ALLOWED" if="cpp" />
+    <define name="VIDEOS_ALLOWED" if="desktop || mobile" />
     <define name="DISCORD_ALLOWED" if="desktop"/>
 
     <!-- _____________________________ Path Settings ____________________________ -->


### PR DESCRIPTION
I don't see the point of keeping the `LINC_LUA_RELATIVE_DYNAMIC_LIB` define inside of project.xml, since the engine doesn't use linc_luajit, also I disabled `DISCORD_ALLOWED` for non-desktop targets, since hxdiscord_rpc is made for Desktop targets only despite it being made for C++ targets.
Also I don't think hxvlc supports emscripten, so I had to set the `VIDEO_ALLOWED` to the current target it uses.