### PR TITLE
More Array Tools

### DIFF
--- a/source/funkin/utils/tools/ArrayTools.hx
+++ b/source/funkin/utils/tools/ArrayTools.hx
@@ -3,8 +3,8 @@ package funkin.utils.tools;
 class ArrayTools
 {
 	/**
-	 * Clears this array in place
-	 * @param array 
+	 * Clears this array in place.
+	 * @param array
 	 * @return Array<T>
 	 */
 	public static function clear<T>(array:Array<T>):Array<T>
@@ -12,5 +12,115 @@ class ArrayTools
 		while (array.length > 0)
 			array.pop();
 		return array;
+	}
+
+	/**
+	 * Shuffles this array in place using Fisher-Yates.
+	 * @param array
+	 * @return Array<T>
+	 */
+	public static function shuffle<T>(array:Array<T>):Array<T>
+	{
+		var i = array.length;
+		while (i > 1)
+		{
+			var j = Std.int(Math.random() * i--);
+			swap(array, i, j);
+		}
+		return array;
+	}
+
+	/**
+	 * Returns the last element, or null if empty.
+	 * @param array
+	 * @return Null<T>
+	 */
+	public static function last<T>(array:Array<T>):Null<T>
+	{
+		return array.length > 0 ? array[array.length - 1] : null;
+	}
+
+	/**
+	 * Removes duplicate values from this array in place.
+	 * @param array
+	 * @return Array<T>
+	 */
+	public static function unique<T>(array:Array<T>):Array<T>
+	{
+		var seen:Array<T> = [];
+		var i = 0;
+		while (i < array.length)
+		{
+			if (seen.indexOf(array[i]) != -1)
+				array.splice(i, 1);
+			else
+				seen.push(array[i++]);
+		}
+		return array;
+	}
+
+	/**
+	 * Returns a new array with all elements from both arrays, without duplicates.
+	 * @param a
+	 * @param b
+	 * @return Array<T>
+	 */
+	public static function union<T>(a:Array<T>, b:Array<T>):Array<T>
+	{
+		var result = a.copy();
+		for (item in b)
+			if (result.indexOf(item) == -1)
+				result.push(item);
+		return result;
+	}
+
+	/**
+	 * Swaps two elements in place by index.
+	 * @param array
+	 * @param i
+	 * @param j
+	 */
+	public static function swap<T>(array:Array<T>, i:Int, j:Int):Void
+	{
+		var tmp = array[i];
+		array[i] = array[j];
+		array[j] = tmp;
+	}
+
+	/**
+	 * Groups elements by a key returned from fn, returning a map of key to matching elements.
+	 * @param array
+	 * @param fn
+	 * @return Map<K, Array<T>>
+	 */
+	public static function groupBy<T, K>(array:Array<T>, fn:T->K):Map<K, Array<T>>
+	{
+		var map = new Map<K, Array<T>>();
+		for (item in array)
+		{
+			var key = fn(item);
+			if (!map.exists(key))
+				map.set(key, []);
+			map.get(key).push(item);
+		}
+		return map;
+	}
+
+	/**
+	 * Splits the array into sub-arrays of the given size.
+	 * @param array
+	 * @param size
+	 * @return Array<Array<T>>
+	 */
+	public static function chunk<T>(array:Array<T>, size:Int):Array<Array<T>>
+	{
+		var result:Array<Array<T>> = [];
+		var i = 0;
+		while (i < array.length)
+		{
+			result.push(array.slice(i, i + size));
+			i += size;
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
adds a handful of util functions to `ArrayTools` that the standard `Array` api doesn't cover. (or atleast that i know of)

## what did i add?

- `shuffle`: [fisher yates](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) in place shuffle
- `last`: returns the last element or null if empty (instead of `array[array.length - 1]`)
- `unique`: removes the duplicate values in place
- `union`: merges two arrays without any duplicates into a new array
- `swap`:  swaps two elements by index in place
- `groupBy` : groups elements by a key function into a `Map`
- `chunk` : splits an array into subarrays of a fixed size

## please note

`shuffle` internally uses `swap` to avoid duplicating the swap logic. `unique` and `shuffle` change in place to stay consistent with the existing `clear` function. `union` returns a new array since there's no clear target to change into.