### PR TITLE
[FIX] Fix an issue where note ratings weren't being set.

### DIFF
--- a/source/funkin/game/Rating.hx
+++ b/source/funkin/game/Rating.hx
@@ -1,5 +1,7 @@
 package funkin.game;
 
+import flixel.util.FlxStringUtil;
+
 import funkin.objects.note.*;
 
 class Rating
@@ -90,5 +92,14 @@ class Rating
 				score = 50;
 				noteSplash = false;
 		}
+	}
+	
+	public function toString():String
+	{
+		return FlxStringUtil.getDebugString([
+			LabelValuePair.weak("name", name),
+			LabelValuePair.weak("ratingMod", ratingMod),
+			LabelValuePair.weak("score", score)
+		]);
 	}
 }

--- a/source/funkin/objects/note/Note.hx
+++ b/source/funkin/objects/note/Note.hx
@@ -1,5 +1,6 @@
 package funkin.objects.note;
 
+import funkin.game.Rating;
 import funkin.backend.math.Vector3;
 
 import flixel.FlxSprite;
@@ -207,8 +208,17 @@ class Note extends FunkinSprite implements funkin.game.modchart.IModNote
 	
 	public var hitHealth:Float = 0.023;
 	public var missHealth:Float = 0.0475;
-	public var rating:String = 'unknown';
-	public var ratingMod:Float = 0; // 9 = unknown, 0.25 = shit, 0.5 = bad, 0.75 = good, 1 = sick
+	public var rating:Rating;
+	
+	@:deprecated("Use Note.rating.ratingMod instead!")
+	public var ratingMod(get, never):Float; // -1 = unknown, 0.25 = shit, 0.5 = bad, 0.75 = good, 1 = sick
+	
+	inline function get_ratingMod():Float
+	{
+		final mod:Float = rating?.ratingMod ?? -1;
+		return mod == 9 ? -1 : mod;
+	}
+	
 	public var ratingDisabled:Bool = false;
 	
 	public var texture(default, set):String = null;

--- a/source/funkin/objects/note/Note.hx
+++ b/source/funkin/objects/note/Note.hx
@@ -208,7 +208,7 @@ class Note extends FunkinSprite implements funkin.game.modchart.IModNote
 	
 	public var hitHealth:Float = 0.023;
 	public var missHealth:Float = 0.0475;
-	public var rating:Rating;
+	public var rating:Null<Rating> = null;
 	
 	@:deprecated("Use Note.rating.ratingMod instead!")
 	public var ratingMod(get, never):Float; // -1 = unknown, 0.25 = shit, 0.5 = bad, 0.75 = good, 1 = sick

--- a/source/funkin/objects/note/PlayField.hx
+++ b/source/funkin/objects/note/PlayField.hx
@@ -404,8 +404,8 @@ class PlayField extends FlxTypedContainer<StrumNote>
 		if (field.playerControls)
 		{
 			var ratingThing:funkin.game.Rating = funkin.game.Rating.judgeNote(note, Math.abs(note.strumTime - Conductor.songPosition + ClientPrefs.ratingOffset) / PlayState.instance?.playbackRate);
-			
-			shouldSplash = (ratingThing.name == 'sick' || ratingThing.name == 'epic');
+			note.rating = ratingThing;
+			shouldSplash = ratingThing.ratingMod >= 1;
 		}
 		
 		if (field.noteSplashes && shouldSplash) field.spawnSplash(note);

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -2725,9 +2725,7 @@ class PlayState extends MusicBeatState
 		var judgeScore:Int = daRating.score;
 		
 		totalNotesHit += daRating.ratingMod;
-		note.ratingMod = daRating.ratingMod;
 		if (!note.ratingDisabled) daRating.increase();
-		note.rating = daRating.name;
 		
 		var field:PlayField = note.playField;
 		


### PR DESCRIPTION
# Description
This fixes an issue where note ratings weren't being set, and also modifies the system for accessing ratings from a `Note`.
Now, you can just do `Note.rating.name` to access the rating's ID, along with being able to access more fields and functions from `Rating`. `Note.ratingMod` was left in as deprecated for backwards compatibility reasons, though.

## Relevant Issues
This fixes #217.