### PR TITLE
Fix an issue where holding Alt and clicking on a note crashed the game.

### DIFF
--- a/source/funkin/states/editors/ChartEditorState.hx
+++ b/source/funkin/states/editors/ChartEditorState.hx
@@ -1319,7 +1319,7 @@ class ChartEditorState extends haxe.ui.backend.flixel.UIState
 					else if (FlxG.keys.pressed.ALT)
 					{
 						selectNote(note);
-						note.chartData[3] = noteTypeIntMap.get(currentType);
+						if (note.chartData != null) note.chartData[3] = noteTypeIntMap.get(currentType);
 						updateGrid();
 					}
 					else

--- a/source/funkin/states/editors/OLDChartEditorState.hx
+++ b/source/funkin/states/editors/OLDChartEditorState.hx
@@ -2136,7 +2136,7 @@ class OLDChartEditorState extends MusicBeatState
 						else if (FlxG.keys.pressed.ALT)
 						{
 							selectNote(note);
-							note.chartData[3] = noteTypeIntMap.get(currentType);
+							if (note.chartData != null) note.chartData[3] = noteTypeIntMap.get(currentType);
 							updateGrid();
 						}
 						else


### PR DESCRIPTION
# Description
This fixes an issue where holding Alt and clicking on a note crashed the game.

## Relevant Issues
This PR fixes #192.

## Why this isn't a duplicate PR
Maybe #203 is related to this? I don't exactly know.
Anyway, the null error was coming from `chartData` specifically, because the array was null. So we just have to make sure the array isn't null before we do anything.